### PR TITLE
Fix in_array and explode warnings

### DIFF
--- a/fancytokens.php
+++ b/fancytokens.php
@@ -78,17 +78,19 @@ function fancytokens_civicrm_tokens( &$tokens ){
 		   	$p_type = "";  
 		   	if( isset( $cur['group_type'])){
 		   		$p_type = $cur['group_type']; 
+          // Some group_types are arrays, if the profile is used on an event form
+          $p_type = is_array($p_type) ? $p_type[0] : $p_type;
+
+  		   	$type_array = explode( "," , $p_type); // Contributions Activity
+		     	if ( false == ( in_array("Participant", $type_array ) || in_array("Membership", $type_array ) || in_array("Household", $type_array ) || in_array("Contributions", $type_array )  || in_array("Activity", $type_array )  )) {
 		   	
-		   	}
-		   	$type_array = explode( "," , $p_type); // Contributions Activity
-		   	if ( false == ( in_array("Participant", $type_array ) || in_array("Membership", $type_array ) || in_array("Household", $type_array ) || in_array("Contributions", $type_array )  || in_array("Activity", $type_array )  )) {
-		   	
-		   		$key = 'communitynews.standaloneprofile___'.$cur['id'] ;
-			    $label = $cur['title'].' (id: '.$cur['id'].') :: Forms'; 
+		     		$key = 'communitynews.standaloneprofile___'.$cur['id'] ;
+			      $label = $cur['title'].' (id: '.$cur['id'].') :: Forms'; 
 			   
-			   $tokens['communitynews'][$key] = $label; 
+			      $tokens['communitynews'][$key] = $label; 
 		   	
 		   	
+		   	  }
 		   	}
 		   }
 	


### PR DESCRIPTION
Hi Sarah,

I love this extension!  However, I noticed that it was filling my Drupal logs with PHP warnings, so I took a look.

This is a typical warning I saw in my log:
```
Warning: in_array() expects parameter 2 to be array, null given in fancytokens_civicrm_tokens() (line 83 of /var/www/mysite.org/public/sites/all/civicrm/extensions/com.pogstone.fancytokens/fancytokens.php).
```

There's two situations that are leading to `$p_type` being null:
* Someone's created a profile but not added fields to it.  Rare, but happens.  I fixed this by putting more of the logic into the `if( isset( $cur['group_type']))` conditional.
* Much more frequently (in this database, anyway) - group_type is storing an array.  Most group_type values look like:
```
$p_type = Individual,Contact,Participant
```

but some look like:
```
$p_type = Array
(
  [0] => Individual,Contact,Participant
  [1] => ParticipantEventName:45:64:77:47:46:59:109:65
}
```

The latter type isn't getting a fancy token - and generates PHP warnings.  So I also added a conditional to only grab $p_type[0] when $p_type is an array.