### PR TITLE
condition check to avoid in_array warning

### DIFF
--- a/fancytokens.php
+++ b/fancytokens.php
@@ -81,14 +81,16 @@ function fancytokens_civicrm_tokens( &$tokens ){
 		   	
 		   	}
 		   	$type_array = explode( "," , $p_type); // Contributions Activity
-		   	if ( false == ( in_array("Participant", $type_array ) || in_array("Membership", $type_array ) || in_array("Household", $type_array ) || in_array("Contributions", $type_array )  || in_array("Activity", $type_array )  )) {
-		   	
-		   		$key = 'communitynews.standaloneprofile___'.$cur['id'] ;
-			    $label = $cur['title'].' (id: '.$cur['id'].') :: Forms'; 
-			   
-			   $tokens['communitynews'][$key] = $label; 
-		   	
-		   	
+		   	if ( is_array( $type_array ) ) {
+			   	if ( false == ( in_array("Participant", $type_array ) || in_array("Membership", $type_array ) || in_array("Household", $type_array ) || in_array("Contributions", $type_array )  || in_array("Activity", $type_array )  )) {
+			   	
+			   		$key = 'communitynews.standaloneprofile___'.$cur['id'] ;
+				    $label = $cur['title'].' (id: '.$cur['id'].') :: Forms'; 
+				   
+				   $tokens['communitynews'][$key] = $label; 
+			   	
+			   	
+			   	}
 		   	}
 		   }
 	


### PR DESCRIPTION
Hi,
We are using this extension in most of our site setups. But we noticed that the following warning just kept coming up, hence we fixed it. 

> E_WARNING: in_array() expects parameter 2 to be array, null given
> in in_array called at /var/www/vhosts/test.example.com/httpdocs/custom_civicrm/extensions/com.pogstone.fancytokens/fancytokens.php (84)

Thanks,
Priyanka
Veda Consulting